### PR TITLE
Constructors must return this

### DIFF
--- a/lib/external_payment.js
+++ b/lib/external_payment.js
@@ -18,6 +18,7 @@ function ExternalPayment(instanceId) {
     }, callback);
   };
 
+  return this;
 }
 
 ExternalPayment.getInstanceId = function(clientId, callback) {

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -62,11 +62,12 @@ function Wallet(accessToken) {
     this.sendAuthenticatedRequest({
       url: "/api/incoming-transfer-reject",
       data: {
-        "operation_id": operation_id,
+        "operation_id": operation_id
       }
     }, callback);
   };
 
+  return this;
 }
 
 


### PR DESCRIPTION
Otherwise examples do not work:
```js
var api = yandexMoney.Wallet(access_token);
// Wallet return undefined
// TypeError: Cannot read property 'accountInfo' of undefined
api.accountInfo(function infoComplete(err, data) {
    // etc..
});
```